### PR TITLE
Fixed import and path issues for Linux

### DIFF
--- a/cutimg.py
+++ b/cutimg.py
@@ -30,7 +30,7 @@ def cut_data(filetype,name,window_size,stride):
     for i in range(len(filedirs)):
         filepath=filedirs[i]
         print(filepath)
-        savedirname=filepath..split('/')[-1].split('\\')[-1].split('.tif')[0][33:44]
+        savedirname=filepath.split('\\')[-1].split('.tif')[0][33:44]
         savedirpath=filedir.replace(filetype,filetype+'DNclips')+"/"+savedirname
         if not os.path.exists(savedirpath):
             os.makedirs(savedirpath)

--- a/fuseimg.py
+++ b/fuseimg.py
@@ -37,12 +37,14 @@ sourcepath=sourcedir+name#the unziped file path
 savepath=sourcedir#savepath
 bands = [['10m','02','03','04','08'],['20m','05','06','07','8A','11','12'],['60m','01','09','10']]
 def fuse_DN(path1):
-    filename=path1.split('/')[-1].split('\\')[-1].split('.SAFE')[0]#[33:44]
+    filename=path1.split('\\')[-1].split('.SAFE')[0]#[33:44]
+    filename = os.path.basename(filename)
     if filename in testlist:
         savepath=sourcedir+"test"
     else:
         savepath=sourcedir+"train"
     print(filename)
+
     filedir1=glob.glob(os.path.join(path1, 'GRANULE'))[0]
     filedir2=glob.glob(os.path.join(filedir1, 'L*'))[0]
     filedir3=glob.glob(os.path.join(filedir2, 'IMG_DATA'))[0]
@@ -64,7 +66,7 @@ def fuse_DN(path1):
         imgwrite(savedir+"/"+filename+'.tif',fusedimg)
 
 def multi_dir(path):
-    filedirs=glob.glob(os.path.join(path, '*'))
+    filedirs=glob.glob(os.path.join(path, 'S2*'))
     for i in range(len(filedirs)):
         filedir=filedirs[i]
         print(filedir)    

--- a/gdaldiy.py
+++ b/gdaldiy.py
@@ -5,7 +5,7 @@ Created on Fri Oct 25 20:57:37 2019
 @author: Neoooli
 """
 
-import gdal
+from osgeo import gdal
 import numpy as np
 
 list1 = ["byte","uint8","uint16","int16","uint32","int32","float32","float64","cint16","cint32","cfloat32","cfloat64"]


### PR DESCRIPTION
The issue is not the slashes, at least not what I noticed. The problem is that GDAL is within the `osgeo` package by default, and that in some cases where `glob` is used the absolute path is returned rather than just the filename. With these changes the code works on Ubuntu.